### PR TITLE
Bump springBootVersion from 2.2.5.RELEASE to 2.2.6.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
         mybatisSpringVersion = '2.0.4',
         mybatisSpringBootStarterVersion = '2.1.2',
         springVersion = '5.2.5.RELEASE',
-        springBootVersion = '2.2.5.RELEASE',
+        springBootVersion = '2.2.6.RELEASE',
         jsqlparserVersion = '3.1',
         junitVersion = '5.6.1',
     ]


### PR DESCRIPTION
Bumps `springBootVersion` from 2.2.5.RELEASE to 2.2.6.RELEASE.

Updates `spring-boot-dependencies` from 2.2.5.RELEASE to 2.2.6.RELEASE
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v2.2.5.RELEASE...v2.2.6.RELEASE)

Updates `spring-boot-configuration-processor` from 2.2.5.RELEASE to 2.2.6.RELEASE
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v2.2.5.RELEASE...v2.2.6.RELEASE)

Updates `spring-boot-autoconfigure-processor` from 2.2.5.RELEASE to 2.2.6.RELEASE
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v2.2.5.RELEASE...v2.2.6.RELEASE)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

### 该Pull Request关联的Issue



### 修改描述



### 测试用例



### 修复效果的截屏


